### PR TITLE
Fix: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,14 @@
   },
   "require-dev": {
     "behat/behat": "^3.3",
-    "phpspec/phpspec": "^4.0",
     "escapestudios/symfony2-coding-standard": "^3.0",
-    "friendsofphp/php-cs-fixer": "^2.5"
+    "friendsofphp/php-cs-fixer": "^2.5",
+    "phpspec/phpspec": "^4.0"
   },
   "prefer-stable": true,
   "config": {
-    "bin-dir": "bin"
+    "bin-dir": "bin",
+    "sort-packages": true
   },
   "archive": {
     "exclude": ["*", "!/src"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "91c7c3a35c5e81a78b2b178378d1d811",
+    "content-hash": "c783daaa1b8779f805efd7adbaf230a6",
     "packages": [
         {
             "name": "eventbus-interop/eventbus-interop",


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.